### PR TITLE
fix: Fix missing content about indent lines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,12 +1004,12 @@ _You can enable the following settings in Xcode by running [this script](resourc
   }
   ```
 
-* <a id='multi-line-conditions'></a>(<a href='#multi-line-conditions'>link</a>) **Multi-line conditional statements should break after the leading keyword.** Indent each individual statement by [2 spaces](https://github.com/airbnb/swift#spaces-over-tabs). [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
+* <a id='multi-line-conditions'></a>(<a href='#multi-line-conditions'>link</a>) **Multi-line conditional statements should break after the leading keyword.** Indent each individual statement by [4 spaces](https://github.com/RakuyoKit/swift#spaces-over-tabs). [![SwiftFormat: wrapArguments](https://img.shields.io/badge/SwiftFormat-wrapArguments-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md#wrapArguments)
 
   <details>
 
   #### Why?
-  Breaking after the leading keyword resets indentation to the standard [2-space grid](https://github.com/airbnb/swift#spaces-over-tabs),
+  Breaking after the leading keyword resets indentation to the standard [4-space grid](https://github.com/RakuyoKit/swift#spaces-over-tabs),
   which helps avoid fighting Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.
 
   ```swift


### PR DESCRIPTION
Supplement to https://github.com/RakuyoKit/swift/pull/2