### PR TITLE
Change `operator_usage_whitespace` lint

### DIFF
--- a/Sources/RakuyoSwiftFormatTool/swiftlint.yml
+++ b/Sources/RakuyoSwiftFormatTool/swiftlint.yml
@@ -23,6 +23,10 @@ excluded:
 colon:
   apply_to_dictionaries: false
 
+operator_usage_whitespace:
+  skip_aligned_constants: false
+  allowed_no_space_operators: [] # Contains "…" and "..<"
+
 indentation: 4
 
 custom_rules:


### PR DESCRIPTION
SwiftLint doc: [Operator Usage Whitespace](https://realm.github.io/SwiftLint/operator_usage_whitespace.html)