### PR TITLE
Increase the severity of existing lint to error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note that brevity is not a primary goal. Code should be made more concise only i
 * These rules should not fight Xcode's <kbd>^</kbd> + <kbd>I</kbd> indentation behavior.
 * We strive to make every rule lintable:
   * If a rule changes the format of the code, it needs to be able to be reformatted automatically (either using [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) or [SwiftLint](https://github.com/realm/SwiftLint) autocorrect).
-  * For rules that don't directly change the format of the code, we should have a lint rule that throws a warning.
+  * For rules that don't directly change the format of the code, we should have a lint rule that throws a warning or error.
   * Exceptions to these rules should be rare and heavily justified.
 
 ## Swift Package Manager command plugin

--- a/Sources/RakuyoSwiftFormatTool/swiftlint.yml
+++ b/Sources/RakuyoSwiftFormatTool/swiftlint.yml
@@ -23,6 +23,27 @@ excluded:
 colon:
   apply_to_dictionaries: false
 
+fatal_error_message:
+  severity: error
+
+legacy_cggeometry_functions:
+  severity: error
+
+legacy_constant:
+  severity: error
+    
+legacy_nsgeometry_functions:
+  severity: error
+    
+return_arrow_whitespace:
+  severity: error
+    
+unowned_variable_capture:
+  severity: error
+    
+void_return:
+  severity: error
+    
 operator_usage_whitespace:
   skip_aligned_constants: false
   allowed_no_space_operators: [] # Contains "…" and "..<"


### PR DESCRIPTION
The use of "fuzzy" rules is not recommended. 

Now that the rules have been set, it is recommended to strictly enforce them.